### PR TITLE
Fixed PyYAML warning YAMLLoadWarning load deprecation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: python
 python:
-- '3.2'
-- '3.3'
-- '3.4'
 - '3.5'
+- '3.6'
+- '3.7'
+- '3.8'
 install: pip install .
 script: py.test
 deploy:

--- a/mssh/config/msshconfig.py
+++ b/mssh/config/msshconfig.py
@@ -32,7 +32,7 @@ class MsshConfig(object):
 	def load(self):
 		if exists(self._file_name):
 			with io.open(self._file_name) as cnf_file:
-				self._parse(yaml.load(cnf_file))
+				self._parse(yaml.full_load(cnf_file))
 		else:
 			self.environments = CnfValue()
 		return self

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import find_packages
 
 setup(
 	name='mssh',
-	version='0.3.3',
+	version='0.3.4',
 	packages=find_packages(),
 	url='https://github.com/foofilers/mssh',
 	license='GPLv3',


### PR DESCRIPTION
I was getting the warning
/Volumes/home/paridin/Devel/myaws/lib/python3.7/site-packages/mssh/config/msshconfig.py:35: YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated, as the default Loader is unsafe. Please read https://msg.pyyaml.org/load for full details.
  self._parse(yaml.load(cnf_file))

https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation

I fixed, hope that was the only issue related.
